### PR TITLE
添加 Test-and-build.yml 在有push和pull_request时自动测试并打包出一个Windows平台的二进制文件

### DIFF
--- a/.github/workflows/Test-and-build.yml
+++ b/.github/workflows/Test-and-build.yml
@@ -1,0 +1,45 @@
+name: Test-and-build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  windows-build:
+
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pyinstaller # pytest
+        if ( Test-Path requirements.txt ) { pip install -r requirements.txt }
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    #- name: Test with pytest
+      #run: |
+        #if ( false ) { pytest }
+    - name: Build the binary
+      run: |
+        pyinstaller --onefile Qbot.py
+      env:
+        CI: false
+    - name: Upload the binary
+      uses: actions/upload-artifact@v4
+      with:
+        name: Qbot-windows.exe
+        path: dist/Qbot.exe

--- a/.github/workflows/Test-and-build.yml
+++ b/.github/workflows/Test-and-build.yml
@@ -22,7 +22,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pyinstaller # pytest
+        python -m pip install flake8 pyinstaller 
+        # pytest
         if ( Test-Path requirements.txt ) { pip install -r requirements.txt }
     - name: Lint with flake8
       run: |
@@ -41,5 +42,5 @@ jobs:
     - name: Upload the binary
       uses: actions/upload-artifact@v4
       with:
-        name: Qbot-windows.exe
+        name: ${{ format('Qbot-{0}-Python{1}.exe', runner.os, matrix.python-version) }}
         path: dist/Qbot.exe


### PR DESCRIPTION
## 添加 GitHub Actions脚本：Test-and-build.yml  

### 触发条件  
- 任意分支有推送  
- 任意分支有拉取请求

### 动作  
1. 检出代码
2. 更新pip，安装flake8 pyinstaller 和项目依赖
3. 用flake8进行语法检查
4. 用pyinstaller打包Qbot.py成exe
5. 提交生成文件到GitHub Actions附件，命名：Qbot-{runner.os}-Python{matrix.python-version}.exe